### PR TITLE
Make ghidra_plugins_path relative

### DIFF
--- a/ghida_plugin/config.py
+++ b/ghida_plugin/config.py
@@ -51,11 +51,10 @@ class GhidaConfiguration(object):
         """
         Set installation default values.
         """
-        ida_plugins = idaapi.idadir("plugins")
+        (plugin, _) = os.path.split(os.path.realpath(__file__))
 
-        self.__ghidra_plugins_path = os.path.join(ida_plugins,
-                                                  "ghida_plugin",
-                                                  "ghidra_plugin")
+        self.__ghidra_plugins_path = os.path.join(plugin, "ghidra_plugin")
+
         if 'linux' in sys.platform:
             self.__ghidra_install_path = LP
             self.__ghidra_headless_path = os.path.join(


### PR DESCRIPTION
IDA plugins can either be installed into your IDA dir (`C:\Program
Files\IDA Pro\plugins`), or into your IDAUSR plugins dir
(`C:\Users\x\AppData\Roaming\Hex-Rays\IDA Pro\plugins`). However, if you
install ghida into your IDAUSR, ghida will fail as it assumes your
`ghidra_plugins_path` is relative to `idaapi.idadir("plugins")`

This patch makes the `ghidra_plugins` dir resolved relatively from
`config.py`, which might not be the best way to solve this.