### PR TITLE
Updated for IDA 7.4, fixed deprecated API calls and added a more verb…

### DIFF
--- a/ghida.py
+++ b/ghida.py
@@ -972,9 +972,9 @@ def decompile_function_wrapper(cache_only=False, do_show=True):
             DECOMP_VIEW.add_comments(comment_list)
 
         return
-    except Exception:
-        print("GhIDA:: [!] Decompilation wrapper error")
-        idaapi.warning("GhIDA decompilation wrapper error")
+    except Exception as e:
+        print("GhIDA:: [!] Decompilation wrapper error: {}".format(e))
+        idaapi.warning("GhIDA decompilation wrapper error {}".format(e))
 
 
 # ------------------------------------------------------------

--- a/ghida_plugin/idaxml.py
+++ b/ghida_plugin/idaxml.py
@@ -2065,8 +2065,8 @@ class XmlExporter(IdaXml):
         if ida_idp.ph_get_id() == ida_idp.PLFM_C166:
             return False
         s = ida_segment.getseg(addr)
-        if s.startEA in self.overlay:
-            return self.overlay[s.startEA]
+        if s.start_ea in self.overlay:
+            return self.overlay[s.start_ea]
         return False
 
     def is_signed_data(self, flags):
@@ -3391,7 +3391,7 @@ class XmlImporter(IdaXml):
             datatype = self.get_attribute(register_var, DATATYPE)
         if self.has_attribute(register_var, DATATYPE_NAMESPACE):
             namespace = self.get_attribute(register_var, DATATYPE_NAMESPACE)
-        idc.define_local_var(func.startEA, func.endEA, reg, name)
+        idc.define_local_var(func.start_ea, func.endEA, reg, name)
         self.update_counter(REGISTER_VAR)
 
     def import_stack_frame(self, stack_frame, func):

--- a/ghida_plugin/lib.py
+++ b/ghida_plugin/lib.py
@@ -268,7 +268,7 @@ def ghidra_headless(address,
                 continue
 
             # User terminated action
-            if idaapi.wasBreak():
+            if idaapi.user_cancelled():
                 # Termiante the process!
                 terminate_process(p.pid)
                 stop = True
@@ -381,7 +381,7 @@ def ghidraaas_checkin(bin_file_path, filename, ghidra_server_url):
             counter += 1
 
             # User terminated action
-            if idaapi.wasBreak():
+            if idaapi.user_cancelled():
                 stop = True
                 print("GhIDA:: [!] Check-in interrupted.")
                 continue
@@ -460,7 +460,7 @@ def ghidraaas_checkout(ghidra_server_url):
             time.sleep(SLEEP_LENGTH)
             counter += 1
 
-            if idaapi.wasBreak():
+            if idaapi.user_cancelled():
                 print("GhIDA:: [!] Check-out interrupted.")
                 stop = True
                 continue
@@ -581,7 +581,7 @@ def ghidraaas_decompile(address,
             time.sleep(SLEEP_LENGTH)
             counter += 1
 
-            if idaapi.wasBreak():
+            if idaapi.user_cancelled():
                 print("GhIDA:: [!] decompilation interrupted.")
                 stop = True
                 continue

--- a/ghida_plugin/utility.py
+++ b/ghida_plugin/utility.py
@@ -262,7 +262,7 @@ def get_current_address():
         return None
 
     # Get function start address
-    ea = func.startEA
+    ea = func.start_ea
     ea = hex(ea).strip("0x").strip("L")
     return ea
 
@@ -278,7 +278,7 @@ def convert_address(ca):
         return None
 
     # Get function start address
-    ea = func.startEA
+    ea = func.start_ea
     ea = hex(ea).strip("0x").strip("L")
     return ea
 


### PR DESCRIPTION
IDA 7.4 disabled backwards compatibility for IDA 6.x api calls. This PR fixes GhIDA to use the new API calls.

I also added some a more verbose error message in "ghida.py".